### PR TITLE
Revert "Add custom Bible verse support via CUSTOM_VERSES variable"

### DIFF
--- a/.github/workflows/daily-bible-diary.yml
+++ b/.github/workflows/daily-bible-diary.yml
@@ -57,7 +57,6 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          CUSTOM_VERSES: ${{ vars.CUSTOM_VERSES }}
           TZ: Asia/Ho_Chi_Minh
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Tự động lấy Tin Mừng hằng ngày (Gospel only) từ USCCB, tạo ghi c
 
 - 🌅 **Daily Automation**: 06:00 Asia/Ho_Chi_Minh (cron 23:00 UTC ngày trước)
 - 📖 **Gospel-Only Scraper**: Lấy đúng phần Tin Mừng (citation + link + full body) tối ưu token
-- 📝 **Custom Verses Support**: Sử dụng câu Kinh thánh tùy chỉnh (vd: "Jeremiah 29:11") thay vì bài đọc hằng ngày
 - 🧩 **Structured Fields**: `gospel_citation`, `gospel_link`, `gospel_body` + combined `Gospel`
 - 🤖 **Gemini Integration**: Model cấu hình qua `GEMINI_MODEL` (mặc định `gemini-1.5-flash`), retry khi MAX_TOKENS
 - 📝 **NKKT Prompt Template**: `template_prompt.txt` (tiếng Việt, placeholder `{date}` & `{bible_content}`)
@@ -57,7 +56,6 @@ Optional **Variables** (Settings → Actions → Variables):
 EMAIL_PROVIDER=gmail
 GEMINI_MODEL=gemini-1.5-flash
 GEMINI_MAX_OUTPUT_TOKENS=800
-CUSTOM_VERSES=Jeremiah 29:11    # Tùy chọn: Sử dụng câu Kinh thánh tùy chỉnh thay vì bài đọc hằng ngày
 DEBUG=true
 ```
 
@@ -71,7 +69,6 @@ EMAIL_PASSWORD=...
 EMAIL_PROVIDER=gmail
 GEMINI_MODEL=gemini-1.5-flash
 GEMINI_MAX_OUTPUT_TOKENS=800
-CUSTOM_VERSES=Jeremiah 29:11    # Tùy chọn: Sử dụng câu Kinh thánh tùy chỉnh
 DEBUG=true
 ```
 
@@ -117,40 +114,6 @@ Tăng giới hạn token:
 export GEMINI_MAX_OUTPUT_TOKENS=1200
 python main.py
 ```
-
-## 📖 Custom Verses Feature
-
-Bạn có thể sử dụng câu Kinh thánh tùy chỉnh thay vì bài đọc hằng ngày bằng cách thiết lập biến `CUSTOM_VERSES`.
-
-### Cách sử dụng:
-
-1. **Trên GitHub Actions**: 
-   - Vào Settings → Actions → Variables
-   - Tạo variable mới tên `CUSTOM_VERSES` với giá trị là địa chỉ câu Kinh thánh (vd: `Jeremiah 29:11`)
-   - Workflow sẽ tự động sử dụng câu này thay vì bài đọc hằng ngày
-
-2. **Chạy thủ công với `workflow_dispatch`**:
-   - Thiết lập `CUSTOM_VERSES` trong Variables
-   - Vào Actions tab → chọn workflow → Run workflow
-   - Email sẽ được gửi với câu Kinh thánh tùy chỉnh
-
-3. **Chạy local**:
-   ```bash
-   export CUSTOM_VERSES="Jeremiah 29:11"
-   python main.py
-   ```
-
-### Định dạng hỗ trợ:
-
-- Câu đơn: `John 3:16`
-- Phạm vi câu: `Psalm 23:1-3` hoặc `Matthew 5:3-10`
-- Các sách được hỗ trợ: Genesis, Exodus, Psalms, Isaiah, Jeremiah, Ezekiel, Daniel, Matthew, Mark, Luke, John, Romans, và nhiều sách khác
-
-### Lưu ý:
-
-- Nếu `CUSTOM_VERSES` không được thiết lập hoặc để trống, hệ thống sẽ tự động lấy bài đọc Tin Mừng hằng ngày từ USCCB
-- Câu Kinh thánh tùy chỉnh được lấy từ cơ sở dữ liệu Kinh thánh tiếng Việt (RVV.SQLite3)
-- Bạn có thể thay đổi `CUSTOM_VERSES` bất cứ lúc nào để sử dụng câu khác
 
 ## ⏱️ Schedule (GitHub Actions)
 

--- a/common/bible_reference_parser.py
+++ b/common/bible_reference_parser.py
@@ -30,13 +30,6 @@ class BibleReferenceParser:
             'psalms': 'Thánh Vịnh',
             'psalm': 'Thánh Vịnh',
             'ps': 'Tv',
-            
-            # Major Prophets
-            'isaiah': 'Isaya', 'isa': 'Is',
-            'jeremiah': 'Tiên Tri Yêrêmya', 'jer': 'Gr',
-            'lamentations': 'Ai Ca', 'lam': 'Ac',
-            'ezekiel': 'Tiên Tri Êzêkiel', 'ezek': 'Êz',
-            'daniel': 'Tiên Tri Ðaniel', 'dan': 'Ðn',
 
             # New Testament (common mappings)
             'matthew': 'Mátthêu', 'matt': 'Mt', 'mt': 'Mt',

--- a/diary/bible_fetcher.py
+++ b/diary/bible_fetcher.py
@@ -7,13 +7,6 @@ import logging
 from datetime import datetime
 from typing import Dict, Optional, Tuple
 
-try:
-    from common.bible_database import BibleDatabase
-    from common.bible_reference_parser import BibleReferenceParser
-except ImportError:
-    BibleDatabase = None
-    BibleReferenceParser = None
-
 logger = logging.getLogger(__name__)
 
 
@@ -21,18 +14,6 @@ class BibleFetcher:
     def __init__(self):
         self.base_url = "https://bible.usccb.org/bible/readings"
         self.headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36'}
-        # Initialize Bible database and parser for custom verses
-        try:
-            if BibleDatabase and BibleReferenceParser:
-                self.bible_db = BibleDatabase()
-                self.reference_parser = BibleReferenceParser()
-            else:
-                self.bible_db = None
-                self.reference_parser = None
-        except Exception as e:
-            logger.warning(f"Could not initialize Bible database for custom verses: {e}")
-            self.bible_db = None
-            self.reference_parser = None
 
     def fetch_daily_reading(self, date: datetime) -> Optional[Dict[str, str]]:
         try:
@@ -89,71 +70,3 @@ class BibleFetcher:
             composed += "\n\n" + body_text
             return composed, citation_text, citation_link, body_text
         return None
-
-    def fetch_custom_verse(self, verse_reference: str, date: datetime) -> Optional[Dict[str, str]]:
-        """
-        Fetch a custom Bible verse by reference (e.g., "Jeremiah 29:11").
-        Uses the Vietnamese Bible database to retrieve the verse.
-        
-        Args:
-            verse_reference: Bible verse reference (e.g., "Jeremiah 29:11" or "John 3:16-17")
-            date: The date to associate with this reading
-            
-        Returns:
-            Dictionary with verse information in the same format as fetch_daily_reading
-        """
-        if not self.bible_db or not self.reference_parser:
-            logger.error("Bible database not available for custom verses. Please ensure database files are present.")
-            return None
-            
-        try:
-            logger.info(f"Fetching custom verse: {verse_reference}")
-            
-            # Parse the verse reference
-            references = self.reference_parser.extract_bible_references(verse_reference)
-            if not references:
-                logger.error(f"Could not parse verse reference: {verse_reference}")
-                return None
-            
-            # Use the first reference found
-            ref = references[0]
-            logger.info(f"Parsed reference: {ref}")
-            
-            # Fetch the verse from the database
-            verse_text = self.bible_db.search_verse_by_reference(
-                ref['book'], 
-                ref['chapter'], 
-                ref['verse_start'], 
-                ref['verse_end']
-            )
-            
-            if not verse_text:
-                logger.error(f"Could not find verse in database: {verse_reference}")
-                return None
-            
-            # Format the citation
-            citation = f"{ref['book']} {ref['chapter']}:{ref['verse_start']}"
-            if ref['verse_end'] and ref['verse_end'] != ref['verse_start']:
-                citation += f"-{ref['verse_end']}"
-            
-            # Create a combined text similar to the daily reading format
-            combined_text = f"{citation}\n\n{verse_text}"
-            
-            return {
-                'date': date.strftime("%A, %B %d, %Y"),
-                'url': f"Custom verse: {verse_reference}",
-                'Gospel': combined_text,
-                'gospel_citation': citation,
-                'gospel_link': '',
-                'gospel_body': verse_text,
-            }
-            
-        except Exception as e:
-            logger.error(f"Error fetching custom verse: {e}")
-            return None
-    
-    def close(self):
-        """Close the database connection if it exists."""
-        if hasattr(self, 'bible_db') and self.bible_db:
-            self.bible_db.close()
-

--- a/main.py
+++ b/main.py
@@ -31,28 +31,11 @@ def main():
         vn_tz = pytz.timezone('Asia/Ho_Chi_Minh')
         current_date = datetime.now(vn_tz)
         
-        # Check if custom verses are provided
-        custom_verses = os.getenv('CUSTOM_VERSES')
-        has_custom_verses = custom_verses and custom_verses.strip()
+        logger.info(f"Starting daily Bible diary generation for {current_date.strftime('%Y-%m-%d')}")
         
-        if has_custom_verses:
-            logger.info(f"Using custom verse: {custom_verses}")
-            logger.info(f"Starting Bible diary generation with custom verse for {current_date.strftime('%Y-%m-%d')}")
-        else:
-            logger.info(f"Starting daily Bible diary generation for {current_date.strftime('%Y-%m-%d')}")
-        
-        # Fetch Bible reading (daily or custom)
+        # Fetch daily Bible reading
         bible_fetcher = BibleFetcher()
-        
-        if has_custom_verses:
-            # Fetch custom verse
-            bible_content = bible_fetcher.fetch_custom_verse(custom_verses.strip(), current_date)
-        else:
-            # Fetch daily reading from USCCB
-            bible_content = bible_fetcher.fetch_daily_reading(current_date)
-        
-        # Close the fetcher to release database connection
-        bible_fetcher.close()
+        bible_content = bible_fetcher.fetch_daily_reading(current_date)
         
         if not bible_content:
             logger.error("Failed to fetch Bible content")


### PR DESCRIPTION
Reverts minhtrung1997/automatic_bible_diary#8
In the run https://github.com/minhtrung1997/automatic_bible_diary/actions/runs/20044583161/job/57487013176#logs
I see
Run set -e
2025-12-09 05:15:23,259 - INFO - Using custom verse: Jeremiah 29:11
2025-12-09 05:15:23,260 - INFO - Starting Bible diary generation with custom verse for 2025-12-09
2025-12-09 05:15:23,260 - INFO - Connected to Bible database: /home/runner/work/automatic_bible_diary/automatic_bible_diary/database/RVV.SQLite3
2025-12-09 05:15:23,260 - INFO - Fetching custom verse: Jeremiah 29:11
2025-12-09 05:15:23,261 - INFO - Parsed reference: {'original_text': 'Jeremiah 29:11-11', 'book': 'Tiên Tri Yêrêmya', 'chapter': 29, 'verse_start': 11, 'verse_end': 11}
2025-12-09 05:15:23,261 - INFO - Successfully fetched Bible readings
2025-12-09 05:15:23,262 - INFO - Connected to Bible database: /home/runner/work/automatic_bible_diary/automatic_bible_diary/database/RVV.SQLite3
2025-12-09 05:15:23,262 - WARNING - No verses found for book_number=160, chapter=29, verses=11-11


It seems like you cannot communicate clearly the custom verse to map the SQL db, please review and change if needed